### PR TITLE
Use JsonNode for comparing Json strings to fix the flaky test

### DIFF
--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
@@ -44,7 +44,7 @@ import java.util.List;
 public class CompatParquetReaderTest extends BaseParquetReaderTest
 {
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
-
+  
   @Test
   public void testBinaryAsString() throws IOException
   {
@@ -97,15 +97,13 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "  \"field\" : \"hey this is &é(-è_çà)=^$ù*! Ω^^\",\n"
                                 + "  \"ts\" : 1471800234\n"
                                 + "}";
-    Assert.assertTrue(JSON_MAPPER.readTree(expectedJson).equals(JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()))));
-    
+    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
     final String expectedJsonBinary = "{\n"
                                 + "  \"field\" : \"aGV5IHRoaXMgaXMgJsOpKC3DqF/Dp8OgKT1eJMO5KiEgzqleXg==\",\n"
                                 + "  \"ts\" : 1471800234\n"
                                 + "}"; 
-    Assert.assertTrue(JSON_MAPPER.readTree(expectedJsonBinary).equals(JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsBinary.get(0).getRawValues()))));
+    Assert.assertEquals(JSON_MAPPER.readTree(expectedJsonBinary), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsBinary.get(0).getRawValues())));
   }
-
 
   @Test
   public void testParquet1217() throws IOException
@@ -143,7 +141,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
     final String expectedJson = "{\n"
                                 + "  \"col\" : -1\n"
                                 + "}";
-    Assert.assertTrue(JSON_MAPPER.readTree(expectedJson).equals(JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()))));
+    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test
@@ -305,7 +303,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    } ]\n"
                                 + "  }\n"
                                 + "}";
-    Assert.assertTrue(JSON_MAPPER.readTree(expectedJson).equals(JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()))));
+    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test
@@ -342,9 +340,8 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
     final String expectedJson = "{\n"
                                 + "  \"repeatedInt\" : [ 1, 2, 3 ]\n"
                                 + "}";
-    Assert.assertTrue(JSON_MAPPER.readTree(expectedJson).equals(JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()))));
+    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
-
 
   @Test
   public void testReadNestedArrayStruct() throws IOException
@@ -385,7 +382,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"repeatedMessage\" : [ 3 ]\n"
                                 + "  } ]\n"
                                 + "}";
-    Assert.assertTrue(JSON_MAPPER.readTree(expectedJson).equals(JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()))));
+    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
   @Test
@@ -435,6 +432,6 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"someId\" : 9\n"
                                 + "  }\n"
                                 + "}";
-    Assert.assertTrue(JSON_MAPPER.readTree(expectedJson).equals(JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()))));
+    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.data.input.parquet;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
@@ -44,6 +43,8 @@ import java.util.List;
  */
 public class CompatParquetReaderTest extends BaseParquetReaderTest
 {
+  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
   @Test
   public void testBinaryAsString() throws IOException
   {
@@ -92,24 +93,17 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
     List<InputRowListPlusRawValues> sampledAsBinary = sampleAllRows(readerNotAsString);
-    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"field\" : \"hey this is &é(-è_çà)=^$ù*! Ω^^\",\n"
                                 + "  \"ts\" : 1471800234\n"
                                 + "}";
-    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
-    JsonNode expected = objectMapper.readTree(expectedJson);
-    JsonNode serialized = objectMapper.readTree(serializedJson);
-    Assert.assertTrue(expected.equals(serialized));
+    Assert.assertTrue(JSON_MAPPER.readTree(expectedJson).equals(JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()))));
+    
     final String expectedJsonBinary = "{\n"
                                 + "  \"field\" : \"aGV5IHRoaXMgaXMgJsOpKC3DqF/Dp8OgKT1eJMO5KiEgzqleXg==\",\n"
                                 + "  \"ts\" : 1471800234\n"
-                                + "}";
-    
-    final String serializedJsonBinary = DEFAULT_JSON_WRITER.writeValueAsString(sampledAsBinary.get(0).getRawValues());
-    JsonNode expectedBinary = objectMapper.readTree(expectedJsonBinary);
-    JsonNode serializedBinary = objectMapper.readTree(serializedJsonBinary);
-    Assert.assertTrue(expectedBinary.equals(serializedBinary));
+                                + "}"; 
+    Assert.assertTrue(JSON_MAPPER.readTree(expectedJsonBinary).equals(JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsBinary.get(0).getRawValues()))));
   }
 
 
@@ -146,14 +140,10 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"col\" : -1\n"
                                 + "}";
-    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
-    JsonNode expected = objectMapper.readTree(expectedJson);
-    JsonNode serialized = objectMapper.readTree(serializedJson);
-    Assert.assertTrue(expected.equals(serialized));
+    Assert.assertTrue(JSON_MAPPER.readTree(expectedJson).equals(JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()))));
   }
 
   @Test
@@ -256,7 +246,6 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"enumColumn\" : \"SPADES\",\n"
                                 + "  \"maybeStringColumn\" : null,\n"
@@ -316,10 +305,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    } ]\n"
                                 + "  }\n"
                                 + "}";
-    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
-    JsonNode expected = objectMapper.readTree(expectedJson);
-    JsonNode serialized = objectMapper.readTree(serializedJson);
-    Assert.assertTrue(expected.equals(serialized));
+    Assert.assertTrue(JSON_MAPPER.readTree(expectedJson).equals(JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()))));
   }
 
   @Test
@@ -353,14 +339,10 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"repeatedInt\" : [ 1, 2, 3 ]\n"
                                 + "}";
-    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
-    JsonNode expected = objectMapper.readTree(expectedJson);
-    JsonNode serialized = objectMapper.readTree(serializedJson);
-    Assert.assertTrue(expected.equals(serialized));
+    Assert.assertTrue(JSON_MAPPER.readTree(expectedJson).equals(JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()))));
   }
 
 
@@ -396,7 +378,6 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"primitive\" : 2,\n"
                                 + "  \"myComplex\" : [ {\n"
@@ -404,10 +385,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"repeatedMessage\" : [ 3 ]\n"
                                 + "  } ]\n"
                                 + "}";
-    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
-    JsonNode expected = objectMapper.readTree(expectedJson);
-    JsonNode serialized = objectMapper.readTree(serializedJson);
-    Assert.assertTrue(expected.equals(serialized));
+    Assert.assertTrue(JSON_MAPPER.readTree(expectedJson).equals(JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()))));
   }
 
   @Test
@@ -447,7 +425,6 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"optionalMessage\" : null,\n"
                                 + "  \"requiredPrimitive\" : 9,\n"
@@ -458,9 +435,6 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"someId\" : 9\n"
                                 + "  }\n"
                                 + "}";
-    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
-    JsonNode expected = objectMapper.readTree(expectedJson);
-    JsonNode serialized = objectMapper.readTree(serializedJson);
-    Assert.assertTrue(expected.equals(serialized));
+    Assert.assertTrue(JSON_MAPPER.readTree(expectedJson).equals(JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()))));
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.data.input.parquet;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
@@ -90,20 +92,24 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
     List<InputRowListPlusRawValues> sampledAsBinary = sampleAllRows(readerNotAsString);
+    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"field\" : \"hey this is &é(-è_çà)=^$ù*! Ω^^\",\n"
                                 + "  \"ts\" : 1471800234\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
-
+    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
+    JsonNode expected = objectMapper.readTree(expectedJson);
+    JsonNode serialized = objectMapper.readTree(serializedJson);
+    Assert.assertTrue(expected.equals(serialized));
     final String expectedJsonBinary = "{\n"
                                 + "  \"field\" : \"aGV5IHRoaXMgaXMgJsOpKC3DqF/Dp8OgKT1eJMO5KiEgzqleXg==\",\n"
                                 + "  \"ts\" : 1471800234\n"
                                 + "}";
-    Assert.assertEquals(
-        expectedJsonBinary,
-        DEFAULT_JSON_WRITER.writeValueAsString(sampledAsBinary.get(0).getRawValues())
-    );
+    
+    final String serializedJsonBinary = DEFAULT_JSON_WRITER.writeValueAsString(sampledAsBinary.get(0).getRawValues());
+    JsonNode expectedBinary = objectMapper.readTree(expectedJsonBinary);
+    JsonNode serializedBinary = objectMapper.readTree(serializedJsonBinary);
+    Assert.assertTrue(expectedBinary.equals(serializedBinary));
   }
 
 
@@ -140,10 +146,14 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
+    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"col\" : -1\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
+    JsonNode expected = objectMapper.readTree(expectedJson);
+    JsonNode serialized = objectMapper.readTree(serializedJson);
+    Assert.assertTrue(expected.equals(serialized));
   }
 
   @Test
@@ -246,6 +256,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
+    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"enumColumn\" : \"SPADES\",\n"
                                 + "  \"maybeStringColumn\" : null,\n"
@@ -305,7 +316,10 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    } ]\n"
                                 + "  }\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
+    JsonNode expected = objectMapper.readTree(expectedJson);
+    JsonNode serialized = objectMapper.readTree(serializedJson);
+    Assert.assertTrue(expected.equals(serialized));
   }
 
   @Test
@@ -339,10 +353,14 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
+    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"repeatedInt\" : [ 1, 2, 3 ]\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
+    JsonNode expected = objectMapper.readTree(expectedJson);
+    JsonNode serialized = objectMapper.readTree(serializedJson);
+    Assert.assertTrue(expected.equals(serialized));
   }
 
 
@@ -378,6 +396,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
+    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"primitive\" : 2,\n"
                                 + "  \"myComplex\" : [ {\n"
@@ -385,7 +404,10 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"repeatedMessage\" : [ 3 ]\n"
                                 + "  } ]\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
+    JsonNode expected = objectMapper.readTree(expectedJson);
+    JsonNode serialized = objectMapper.readTree(serializedJson);
+    Assert.assertTrue(expected.equals(serialized));
   }
 
   @Test
@@ -425,6 +447,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
+    ObjectMapper objectMapper = new ObjectMapper();
     final String expectedJson = "{\n"
                                 + "  \"optionalMessage\" : null,\n"
                                 + "  \"requiredPrimitive\" : 9,\n"
@@ -435,6 +458,9 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"someId\" : 9\n"
                                 + "  }\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    final String serializedJson = DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues());
+    JsonNode expected = objectMapper.readTree(expectedJson);
+    JsonNode serialized = objectMapper.readTree(serializedJson);
+    Assert.assertTrue(expected.equals(serialized));
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.data.input.parquet;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
@@ -95,7 +94,6 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-
     Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
@@ -208,11 +206,9 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    ObjectMapper obj = new ObjectMapper();
-    JsonNode expectedJson = obj.readTree(FLAT_JSON);
+    ObjectMapper mapper = new ObjectMapper();
 
-    JsonNode sampledAsStringJson = obj.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
-    Assert.assertEquals(expectedJson, sampledAsStringJson);
+    Assert.assertEquals(mapper.readTree(FLAT_JSON), mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 
 

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
@@ -96,11 +96,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
 
-    ObjectMapper obj = new ObjectMapper();
-    JsonNode expectedJson = obj.readTree(FLAT_JSON);
-
-    JsonNode sampledAsStringJson = obj.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
-    Assert.assertEquals(expectedJson, sampledAsStringJson);
+    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
   @Test

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
@@ -36,11 +36,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
 /**
  * Duplicate of {@link FlattenSpecParquetInputTest} but for {@link ParquetReader} instead of Hadoop
@@ -48,10 +44,10 @@ import java.util.TreeSet;
 public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
 {
   private static final String FLAT_JSON = "{\n"
-                                          + "  \"dim1\" : \"d1v1\",\n"
-                                          + "  \"dim2\" : \"d2v1\",\n"
-                                          + "  \"dim3\" : 1,\n"
                                           + "  \"listDim\" : [ \"listDim1v1\", \"listDim1v2\" ],\n"
+                                          + "  \"dim3\" : 1,\n"
+                                          + "  \"dim2\" : \"d2v1\",\n"
+                                          + "  \"dim1\" : \"d1v1\",\n"
                                           + "  \"metric1\" : 1,\n"
                                           + "  \"timestamp\" : 1537229880023\n"
                                           + "}";
@@ -216,14 +212,11 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Map<String, Object> map = sampled.get(0).getRawValues();
-    SortedSet<String> keys = new TreeSet<>(map.keySet());
-    Map<String, Object> newMap = new LinkedHashMap<String, Object>();
-    for (String key : keys) { 
-      Object value = map.get(key);
-      newMap.put(key, value);
-    }
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(newMap));
+    ObjectMapper obj = new ObjectMapper();
+    JsonNode expectedJson = obj.readTree(FLAT_JSON);
+
+    JsonNode sampledAsStringJson = obj.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assert.assertEquals(expectedJson, sampledAsStringJson);
   }
 
 

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
@@ -92,9 +92,7 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
                                       + "  \"idx\" : 1,\n"
                                       + "  \"date_as_date\" : 1497744000000\n"
                                       + "}";
-
     ObjectMapper mapper = new ObjectMapper();
-
     Assert.assertEquals(mapper.readTree(expectedJson), mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues())));
     Assert.assertEquals(mapper.readTree(expectedJson), mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues())));
   }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.data.input.parquet;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
@@ -86,7 +85,7 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
     );
     List<InputRowListPlusRawValues> sampledAsString = sampleAllRows(readerAsString);
     List<InputRowListPlusRawValues> sampledAsDate = sampleAllRows(readerAsDate);
-    final String expectedJsonString = "{\n"
+    final String expectedJson = "{\n"
                                       + "  \"date_as_string\" : \"2017-06-18\",\n"
                                       + "  \"timestamp_as_timestamp\" : 1497702471815,\n"
                                       + "  \"timestamp_as_string\" : \"2017-06-17 14:27:51.815\",\n"
@@ -94,13 +93,10 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
                                       + "  \"date_as_date\" : 1497744000000\n"
                                       + "}";
 
-    ObjectMapper obj = new ObjectMapper();
-    JsonNode expectedJson = obj.readTree(expectedJsonString);
+    ObjectMapper mapper = new ObjectMapper();
 
-    JsonNode sampledAsStringJson = obj.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()));
-    JsonNode sampledAsDateJson = obj.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()));
-    Assert.assertEquals(expectedJson, sampledAsStringJson);
-    Assert.assertEquals(expectedJson, sampledAsDateJson);
+    Assert.assertEquals(mapper.readTree(expectedJson), mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues())));
+    Assert.assertEquals(mapper.readTree(expectedJson), mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues())));
   }
 
   @Test

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.druid.data.input.parquet;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
@@ -84,15 +86,21 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
     );
     List<InputRowListPlusRawValues> sampledAsString = sampleAllRows(readerAsString);
     List<InputRowListPlusRawValues> sampledAsDate = sampleAllRows(readerAsDate);
-    final String expectedJson = "{\n"
+    final String expectedJsonString = "{\n"
                                       + "  \"date_as_string\" : \"2017-06-18\",\n"
                                       + "  \"timestamp_as_timestamp\" : 1497702471815,\n"
                                       + "  \"timestamp_as_string\" : \"2017-06-17 14:27:51.815\",\n"
                                       + "  \"idx\" : 1,\n"
                                       + "  \"date_as_date\" : 1497744000000\n"
                                       + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()));
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()));
+
+    ObjectMapper obj = new ObjectMapper();
+    JsonNode expectedJson = obj.readTree(expectedJsonString);
+
+    JsonNode sampledAsStringJson = obj.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()));
+    JsonNode sampledAsDateJson = obj.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()));
+    Assert.assertEquals(expectedJson, sampledAsStringJson);
+    Assert.assertEquals(expectedJson, sampledAsDateJson);
   }
 
   @Test


### PR DESCRIPTION
### Description
Fixed the flaky test `testDateHandling` inside `TimestampsParquetReaderTest` class. 

https://github.com/prathyushreddylpr/druid/blob/ad32f8458670339808a3136a9578a10a52b8394f/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java#L40

#### Root Cause
The test `testDateHandling` has been reported as flaky when run with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The test failed because it is trying to compare two Json strings, but since the JSON library used here is internally using HashMap. The HashMap in Java is implemented in such a way that it does not store the order in which the keys and values are inserted. As a result, when the expected Json string(which is hard-coded) is compared with the actual one, it caused the failure. 

#### Fix
This test is fixed using the Jackson library which contains classes JsonNode and ObjectMapper. These are used to parse two JSON strings to tree models and then compare these trees node by node. So when we use this, the order of the elements in the JSON strings is ignored and only the content is checked.

### How this has been tested?

**Java:** openjdk version "11.0.20.1"
**Maven:** Apache Maven 3.6.3

1) **Module build** - Successful
Command used - 
```
mvn install -pl infra/common -am -DskipTests
```

2) **Regular test**  - Successful
Command used - 
```
mvn -pl extensions-core/parquet-extensions test -Dtest=org.apache.druid.data.input.parquet.TimestampsParquetReaderTest#testDateHandling
```

3) **NonDex test**  - Failed
Command used - 
```
mvn -pl extensions-core/parquet-extensions edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.data.input.parquet.TimestampsParquetReaderTest#testDateHandling
```

NonDex test passed after the fix.



<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->


<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.

